### PR TITLE
Add FastAPI health endpoint

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -1,7 +1,23 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+# Allow all origins for now. The Flutter app will run on a different port
+# during development, so permissive CORS simplifies local testing.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 def read_root():
     return {"message": "Hello World"}
+
+
+@app.get("/health")
+def health_check():
+    """Simple health check endpoint used by deployment probes."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add permissive CORS configuration
- expose `/health` route that reports status

## Testing
- `poetry run pytest`
- `bash ../scripts/run_api.sh` & `curl -s http://localhost:8000/health`