### PR TITLE
Add env-based settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for the WhereIsThisPlace API
+
+MODEL_PATH=/path/to/model.pt
+MAPBOX_TOKEN=your-mapbox-token
+# Optional: how many hours images are stored (default 24)
+IMAGE_TTL_HOURS=24

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,15 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    MODEL_PATH: str
+    MAPBOX_TOKEN: str
+    IMAGE_TTL_HOURS: int = 24
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add environment-based Settings using Pydantic
- document variables in `.env.example`

## Testing
- `poetry run pytest`