### PR TITLE
Adjust sys.path in FastAPI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ poetry install
 poetry run uvicorn api.main:app --reload
 ```
 
+`api/api/main.py` now adjusts `sys.path` automatically so the server can be launched from any directory.
+
 You can also start the backend using the helper script from the project root:
 
 ```bash

--- a/api/api/main.py
+++ b/api/api/main.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 


### PR DESCRIPTION
## Summary
- update `api/api/main.py` to append the project root to `sys.path`
- document the automatic path adjustment in `README.md`

## Testing
- `poetry run pytest -q`
- `poetry run uvicorn api.main:app --reload`