### PR TITLE
Add ephemeral upload middleware and tests

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -8,6 +8,7 @@ if str(ROOT) not in sys.path:
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routes.predict import router as predict_router
+from api.middleware import EphemeralUploadMiddleware
 
 app = FastAPI()
 
@@ -19,6 +20,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(EphemeralUploadMiddleware)
 
 app.include_router(predict_router)
 

--- a/api/api/middleware/__init__.py
+++ b/api/api/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .ephemeral import EphemeralUploadMiddleware
+
+__all__ = ["EphemeralUploadMiddleware"]

--- a/api/api/middleware/ephemeral.py
+++ b/api/api/middleware/ephemeral.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class EphemeralUploadMiddleware(BaseHTTPMiddleware):
+    """Save request body to a temporary file and remove it after the response."""
+
+    async def dispatch(self, request: Request, call_next):
+        body = await request.body()
+        request._body = body
+        fd, path = tempfile.mkstemp(dir="/tmp", prefix="upload_", suffix=".bin")
+        with os.fdopen(fd, "wb") as tmp:
+            tmp.write(body)
+        print(f"Saved upload to {path}")
+        try:
+            response = await call_next(request)
+        finally:
+            try:
+                os.unlink(path)
+                print(f"Deleted upload {path}")
+            except FileNotFoundError:
+                pass
+        return response

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1,12 +1,13 @@
 import sys
 from pathlib import Path
-from fastapi import FastAPI
 import asyncio
 
 API_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ROOT = API_ROOT.parent
 sys.path.append(str(API_ROOT))
 sys.path.append(str(PROJECT_ROOT))
+
+from fastapi import FastAPI
 
 from api.main import app
 
@@ -32,3 +33,4 @@ def test_predict_endpoint_returns_location():
     file = DummyUploadFile(b"dummy")
     data = asyncio.run(predict(photo=file))
     assert data == {"latitude": 0.0, "longitude": 0.0, "confidence": 0.1}
+

--- a/api/tests/test_ephemeral_middleware.py
+++ b/api/tests/test_ephemeral_middleware.py
@@ -1,0 +1,33 @@
+import os
+import re
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+API_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = API_ROOT.parent
+sys.path.append(str(API_ROOT))
+sys.path.append(str(PROJECT_ROOT))
+
+from api.middleware import EphemeralUploadMiddleware
+
+app = FastAPI()
+app.add_middleware(EphemeralUploadMiddleware)
+
+@app.post('/upload')
+async def upload(request: Request):
+    data = await request.body()
+    return {'size': len(data)}
+
+client = TestClient(app)
+
+def test_upload_removed_and_logged(capsys):
+    response = client.post('/upload', data=b'dummy')
+    assert response.status_code == 200
+    logs = capsys.readouterr().out
+    match = re.search(r"Saved upload to (.+)", logs)
+    assert match is not None
+    path = match.group(1).strip()
+    assert not os.path.exists(path)


### PR DESCRIPTION
## Summary
- save request bodies to `/tmp` using new EphemeralUploadMiddleware
- remove the temporary file after the response and log actions
- expose middleware in package
- apply middleware in `main.py`
- fix test import order so multipart stub works
- add middleware tests

## Testing
- `poetry run pytest -q`
- `poetry run uvicorn api.main:app --port 8000 --lifespan=off`