### PR TITLE
Add simple IP-based rate limiter

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -8,7 +8,7 @@ if str(ROOT) not in sys.path:
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routes.predict import router as predict_router
-from api.middleware import EphemeralUploadMiddleware
+from api.middleware import EphemeralUploadMiddleware, RateLimitMiddleware
 
 app = FastAPI()
 
@@ -21,6 +21,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(EphemeralUploadMiddleware)
+app.add_middleware(RateLimitMiddleware)
 
 app.include_router(predict_router)
 

--- a/api/api/middleware/__init__.py
+++ b/api/api/middleware/__init__.py
@@ -1,3 +1,4 @@
 from .ephemeral import EphemeralUploadMiddleware
+from .ratelimit import RateLimitMiddleware
 
-__all__ = ["EphemeralUploadMiddleware"]
+__all__ = ["EphemeralUploadMiddleware", "RateLimitMiddleware"]

--- a/api/api/middleware/ratelimit.py
+++ b/api/api/middleware/ratelimit.py
@@ -1,0 +1,27 @@
+import time
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple in-memory token bucket rate limiter per client IP."""
+
+    def __init__(self, app, limit: int = 10, period: int = 86400):
+        super().__init__(app)
+        self.limit = limit
+        self.period = period
+        self.buckets: dict[str, tuple[int, float]] = {}
+
+    async def dispatch(self, request: Request, call_next):
+        client_ip = request.client.host if request.client else "unknown"
+        now = time.time()
+        tokens, last = self.buckets.get(client_ip, (self.limit, now))
+        if now - last > self.period:
+            tokens = self.limit
+            last = now
+        if tokens <= 0:
+            return Response("Too Many Requests", status_code=429)
+        tokens -= 1
+        self.buckets[client_ip] = (tokens, last)
+        return await call_next(request)

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -34,3 +34,9 @@ def test_predict_endpoint_returns_location():
     data = asyncio.run(predict(photo=file))
     assert data == {"latitude": 0.0, "longitude": 0.0, "confidence": 0.1}
 
+
+def test_rate_limit_middleware_added():
+    from api.middleware import RateLimitMiddleware
+    middleware_classes = {m.cls for m in app.user_middleware}
+    assert RateLimitMiddleware in middleware_classes
+

--- a/api/tests/test_rate_limit_middleware.py
+++ b/api/tests/test_rate_limit_middleware.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+API_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = API_ROOT.parent
+sys.path.append(str(API_ROOT))
+sys.path.append(str(PROJECT_ROOT))
+
+from api.middleware import RateLimitMiddleware
+
+app = FastAPI()
+app.add_middleware(RateLimitMiddleware)
+
+@app.get('/limited')
+async def limited():
+    return {'ok': True}
+
+client = TestClient(app)
+
+def test_rate_limit_exceeded():
+    for _ in range(10):
+        resp = client.get('/limited')
+        assert resp.status_code == 200
+    resp = client.get('/limited')
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- implement `RateLimitMiddleware` using a token bucket
- export the middleware and register it in the FastAPI app
- test that 11th request gets HTTP 429
- verify middleware added to the app

## Testing
- `poetry run pytest -q`
- `poetry run uvicorn api.main:app --port 8000 --log-level warning &`