### PR TITLE
Add API endpoint tests

### DIFF
--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import importlib
+import asyncio
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "api"))
+sys.path.append(str(ROOT))
+
+import api.main
+from routes.predict import predict
+
+
+def get_fresh_client():
+    importlib.reload(api.main)
+    return TestClient(api.main.app)
+
+
+class DummyUploadFile:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    async def read(self) -> bytes:
+        return self.data
+
+
+def test_health_endpoint_returns_200():
+    client = get_fresh_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_predict_returns_expected_data():
+    file = DummyUploadFile(b"dummy")
+    result = asyncio.run(predict(photo=file))
+    assert result == {"latitude": 0.0, "longitude": 0.0, "confidence": 0.1}
+
+
+def test_rate_limit_returns_429_after_limit_exceeded():
+    client = get_fresh_client()
+    for _ in range(10):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+    resp = client.get("/health")
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- add tests for health, predict, and rate limiting under `/tests`

## Testing
- `poetry run pytest tests ../tests -q`