### PR TITLE
Add result screen and tests

### DIFF
--- a/app/lib/screens/home.dart
+++ b/app/lib/screens/home.dart
@@ -1,11 +1,16 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
+import '../models/result_model.dart';
+import '../services/api.dart';
+import 'result.dart';
+
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+  final Api api;
+  const HomeScreen({super.key, Api? api}) : api = api ?? Api();
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -14,6 +19,13 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   XFile? _image;
   bool _loading = false;
+
+  @visibleForTesting
+  void setImageForTest(XFile file) {
+    setState(() {
+      _image = file;
+    });
+  }
 
   Future<void> _pickImage() async {
     final picker = ImagePicker();
@@ -29,11 +41,17 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       _loading = true;
     });
-    await Future.delayed(const Duration(seconds: 1));
+    final result = await widget.api.locate(File(_image!.path));
     if (!mounted) return;
     setState(() {
       _loading = false;
     });
+    if (!mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ResultScreen(result: result),
+      ),
+    );
   }
 
   Widget _buildImagePreview() {

--- a/app/lib/screens/result.dart
+++ b/app/lib/screens/result.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/result_model.dart';
+
+/// Displays the prediction result using a static Mapbox map image.
+class ResultScreen extends StatelessWidget {
+  final ResultModel result;
+  const ResultScreen({super.key, required this.result});
+
+  /// Builds the Mapbox static map URL with a pin at the predicted coordinates.
+  String get _mapUrl {
+    const token = 'YOUR_MAPBOX_ACCESS_TOKEN';
+    final lat = result.latitude;
+    final lon = result.longitude;
+    return 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/'
+        'pin-s+ff0000($lon,$lat)/$lon,$lat,12/600x400?access_token=$token';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Result'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: () {
+              Clipboard.setData(
+                ClipboardData(
+                  text:
+                      'https://maps.google.com/?q=${result.latitude},${result.longitude}',
+                ),
+              );
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Location copied to clipboard')),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Image.network(_mapUrl, fit: BoxFit.cover),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              'Confidence: ${(result.confidence * 100).toStringAsFixed(2)}%',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,7 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 
 import 'package:app/main.dart';
+import 'package:app/models/result_model.dart';
+import 'package:app/screens/home.dart';
+import 'package:app/screens/result.dart';
+import 'package:app/services/api.dart';
 
 void main() {
   testWidgets('Home screen has expected widgets', (WidgetTester tester) async {
@@ -10,4 +17,35 @@ void main() {
     expect(find.text('Locate'), findsOneWidget);
     expect(find.text('No image selected'), findsOneWidget);
   });
+
+  testWidgets('Navigate to result screen on locate', (WidgetTester tester) async {
+    final fakeApi = _FakeApi();
+    await tester.pumpWidget(MaterialApp(home: HomeScreen(api: fakeApi)));
+
+    final state = tester.state(find.byType(HomeScreen)) as dynamic;
+    state.setImageForTest(XFile('dummy.jpg'));
+    await tester.pump();
+
+    await tester.tap(find.text('Locate'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ResultScreen), findsOneWidget);
+    expect(find.text('Confidence: 75.00%'), findsOneWidget);
+  });
+
+  testWidgets('Result screen shows map and share icon', (WidgetTester tester) async {
+    final result = ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
+    await tester.pumpWidget(MaterialApp(home: ResultScreen(result: result)));
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.byIcon(Icons.share), findsOneWidget);
+    expect(find.text('Confidence: 50.00%'), findsOneWidget);
+  });
+}
+
+class _FakeApi extends Api {
+  @override
+  Future<ResultModel> locate(File file) async {
+    return ResultModel(latitude: 10, longitude: 20, confidence: 0.75);
+  }
 }


### PR DESCRIPTION
## Summary
- show geolocation results with Mapbox static map
- navigate to result page after locating
- share/copy coordinates on result page
- test navigation from home and result page UI

## Testing
- `flutter test` *(fails: `flutter: command not found`)*
- `python3 -m pytest tests/test_app_endpoints.py -q` *(fails: `No module named pytest`)*