### PR TITLE
Add result screen with navigation

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const HomeScreen(),
+      home: HomeScreen(),
     );
   }
 }

--- a/app/lib/screens/home.dart
+++ b/app/lib/screens/home.dart
@@ -4,16 +4,29 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
+import '../models/result_model.dart';
+import '../services/api.dart';
+import 'result.dart';
+
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+  final XFile? initialImage;
+
+  HomeScreen({super.key, this.initialImage});
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  final Api _api = Api();
   XFile? _image;
   bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _image = widget.initialImage;
+  }
 
   Future<void> _pickImage() async {
     final picker = ImagePicker();
@@ -29,11 +42,18 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       _loading = true;
     });
-    await Future.delayed(const Duration(seconds: 1));
+    final file = File(_image!.path);
+    final result = await _api.locate(file);
     if (!mounted) return;
     setState(() {
       _loading = false;
     });
+    if (!mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ResultScreen(result: result),
+      ),
+    );
   }
 
   Widget _buildImagePreview() {

--- a/app/lib/screens/result.dart
+++ b/app/lib/screens/result.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/result_model.dart';
+
+class ResultScreen extends StatelessWidget {
+  final ResultModel result;
+
+  const ResultScreen({super.key, required this.result});
+
+  void _shareLocation() {
+    final url = 'https://www.google.com/maps/search/?api=1&query=${result.latitude},${result.longitude}';
+    Share.share('Check out this location: '+url);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mapUrl = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/pin-s(${result.longitude},${result.latitude})/${result.longitude},${result.latitude},14/600x400?access_token=MAPBOX_ACCESS_TOKEN';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Result'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: _shareLocation,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Image.network(
+            mapUrl,
+            height: 300,
+            width: double.infinity,
+            fit: BoxFit.cover,
+          ),
+          const SizedBox(height: 16),
+          Text('Confidence: ${(result.confidence * 100).toStringAsFixed(2)}%'),
+        ],
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   image_picker: ^1.0.4
+  share_plus: ^7.2.1
 
 dev_dependencies:
   flutter_test:

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:app/main.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:app/screens/home.dart';
+import 'package:app/screens/result.dart';
 
 void main() {
   testWidgets('Home screen has expected widgets', (WidgetTester tester) async {
@@ -9,5 +12,18 @@ void main() {
     expect(find.text('Pick Image'), findsOneWidget);
     expect(find.text('Locate'), findsOneWidget);
     expect(find.text('No image selected'), findsOneWidget);
+  });
+
+  testWidgets('Navigate from home to result page', (WidgetTester tester) async {
+    final widget = MaterialApp(
+      home: HomeScreen(initialImage: XFile('dummy.png')),
+    );
+
+    await tester.pumpWidget(widget);
+
+    await tester.tap(find.text('Locate'));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    expect(find.byType(ResultScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add ResultScreen with Mapbox static map and share button
- navigate to result page after locating in HomeScreen
- expose initialImage for widget tests and remove const usage
- update main to use non-const HomeScreen
- cover navigation in widget tests

## Testing
- `poetry run pytest -q`