### PR TITLE
Add GeoProvider for locating images

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'screens/home.dart';
 import 'services/api.dart';
+import 'providers/geo_provider.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,12 +13,15 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+    return ChangeNotifierProvider(
+      create: (_) => GeoProvider(Api()),
+      child: MaterialApp(
+        title: 'Flutter Demo',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        ),
+        home: const HomeScreen(),
       ),
-      home: HomeScreen(api: Api()),
     );
   }
 }

--- a/app/lib/providers/geo_provider.dart
+++ b/app/lib/providers/geo_provider.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+
+import '../models/result_model.dart';
+import '../services/api.dart';
+
+/// ChangeNotifier that performs geolocation requests and stores the last result.
+class GeoProvider extends ChangeNotifier {
+  final Api api;
+
+  GeoProvider(this.api);
+
+  ResultModel? _result;
+  ResultModel? get result => _result;
+
+  /// Calls the API to locate the image in [file] and stores the returned result.
+  /// The result is also returned for convenience.
+  Future<ResultModel> locate(File file) async {
+    final res = await api.locate(file);
+    _result = res;
+    notifyListeners();
+    return res;
+  }
+}

--- a/app/lib/screens/home.dart
+++ b/app/lib/screens/home.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import '../services/api.dart';
+import 'package:provider/provider.dart';
+import '../providers/geo_provider.dart';
 import 'result.dart';
 
 class HomeScreen extends StatefulWidget {
-  final Api api;
-  HomeScreen({super.key, required this.api});
+  const HomeScreen({super.key});
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -39,7 +39,8 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       _loading = true;
     });
-    final result = await widget.api.locate(File(_image!.path));
+    final geo = context.read<GeoProvider>();
+    final result = await geo.locate(File(_image!.path));
     if (!mounted) return;
     setState(() {
       _loading = false;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,8 +38,9 @@ dependencies:
   mapbox_gl:
       git:
         url: https://github.com/tobrun/flutter-mapbox-gl.git
-        ref: master 
+        ref: master
   share_plus: ^7.2.1
+  provider: ^6.1.1
 
 dev_dependencies:
   flutter_test:

--- a/app/test/geo_provider_test.dart
+++ b/app/test/geo_provider_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:app/providers/geo_provider.dart';
+import 'package:app/services/api.dart';
+import 'package:app/models/result_model.dart';
+
+void main() {
+  test('locate stores result and notifies listeners', () async {
+    final provider = GeoProvider(_FakeApi());
+    var notified = false;
+    provider.addListener(() => notified = true);
+    final result = await provider.locate(File('dummy'));
+    expect(notified, isTrue);
+    expect(result.latitude, 1);
+    expect(provider.result, isNotNull);
+    expect(provider.result!.latitude, 1);
+  });
+}
+
+class _FakeApi extends Api {
+  @override
+  Future<ResultModel> locate(File file) async {
+    return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
+  }
+}

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -7,6 +7,8 @@ import 'dart:typed_data';
 import 'package:app/main.dart';
 import 'package:app/screens/home.dart';
 import 'package:app/services/api.dart';
+import 'package:app/providers/geo_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:app/models/result_model.dart';
 import 'package:mapbox_gl/mapbox_gl.dart';
 import 'package:image_picker/image_picker.dart';
@@ -22,7 +24,12 @@ void main() {
   testWidgets('Navigate from home to result page', (WidgetTester tester) async {
     final key = GlobalKey();
     final api = _FakeApi();
-    await tester.pumpWidget(MaterialApp(home: HomeScreen(key: key, api: api)));
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => GeoProvider(api),
+        child: MaterialApp(home: HomeScreen(key: key)),
+      ),
+    );
 
     final dummy = XFile.fromData(Uint8List(0), name: 'dummy.png');
     (key.currentState as dynamic).setImage(dummy);


### PR DESCRIPTION
## Summary
- add `GeoProvider` ChangeNotifier to hold the latest `ResultModel`
- wrap `MaterialApp` with `ChangeNotifierProvider`
- update `HomeScreen` to use `GeoProvider`
- update tests and add unit test for provider
- declare provider dependency in `pubspec.yaml`

## Testing
- `python -m pytest` *(fails: No module named pytest)*