### PR TITLE
Add OpenAI LLM toggle

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'screens/home.dart';
 import 'services/api.dart';
 import 'providers/geo_provider.dart';
+import 'providers/settings_provider.dart';
 
 void main() {
   runApp(const MyApp());
@@ -13,8 +14,11 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => GeoProvider(Api()),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => GeoProvider(Api())),
+        ChangeNotifierProvider(create: (_) => SettingsProvider()),
+      ],
       child: MaterialApp(
         title: 'Flutter Demo',
         theme: ThemeData(

--- a/app/lib/providers/settings_provider.dart
+++ b/app/lib/providers/settings_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsProvider extends ChangeNotifier {
+  static const _sendToLlmKey = 'send_to_llm';
+  bool _sendToLlm = false;
+  bool get sendToLlm => _sendToLlm;
+
+  SettingsProvider() {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _sendToLlm = prefs.getBool(_sendToLlmKey) ?? false;
+    notifyListeners();
+  }
+
+  Future<void> toggleSendToLlm(bool value) async {
+    _sendToLlm = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_sendToLlmKey, value);
+    notifyListeners();
+  }
+}

--- a/app/lib/screens/home.dart
+++ b/app/lib/screens/home.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import '../providers/geo_provider.dart';
 import 'result.dart';
+import 'settings.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -67,6 +68,19 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Home'),
+        actions: [
+          IconButton(
+            key: const Key('settings_button'),
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const SettingsScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Center(
         child: Column(

--- a/app/lib/screens/settings.dart
+++ b/app/lib/screens/settings.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/settings_provider.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = context.watch<SettingsProvider>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            key: const Key('send_to_llm_toggle'),
+            title: const Text('Send to OpenAI LLM'),
+            value: settings.sendToLlm,
+            onChanged: settings.toggleSendToLlm,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
         ref: master
   share_plus: ^7.2.1
   provider: ^6.1.1
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:

--- a/app/test/settings_provider_test.dart
+++ b/app/test/settings_provider_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:app/providers/settings_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('defaults to false when no value stored', () async {
+    final provider = SettingsProvider();
+    await Future.delayed(Duration.zero);
+    expect(provider.sendToLlm, isFalse);
+  });
+
+  test('toggle persists value', () async {
+    var provider = SettingsProvider();
+    await Future.delayed(Duration.zero);
+    await provider.toggleSendToLlm(true);
+
+    provider = SettingsProvider();
+    await Future.delayed(Duration.zero);
+    expect(provider.sendToLlm, isTrue);
+  });
+}

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -19,6 +19,7 @@ void main() {
     expect(find.text('Pick Image'), findsOneWidget);
     expect(find.text('Locate'), findsOneWidget);
     expect(find.text('No image selected'), findsOneWidget);
+    expect(find.byKey(const Key('settings_button')), findsOneWidget);
   });
 
   testWidgets('Navigate from home to result page', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- add `shared_preferences` dependency
- implement `SettingsProvider` with persistence
- create `SettingsScreen` with toggle
- wire settings provider into `MyApp`
- add settings button in `HomeScreen`
- test settings provider persistence
- check for settings button in widget test

## Testing
- `poetry run pytest -q`
- `flutter test` *(fails: `flutter: command not found`)*