### PR TITLE
Fix localization setup causing null error

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,7 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'providers/geo_provider.dart';
+import 'providers/locale_provider.dart';
+import 'providers/settings_provider.dart';
 import 'screens/home_screen.dart';      // ← this is already in the repo
+import 'l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 void main() => runApp(const WhereApp());
 
@@ -14,15 +18,29 @@ class WhereApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => GeoProvider()),
+        ChangeNotifierProvider(create: (_) => SettingsProvider()),
+        ChangeNotifierProvider(create: (_) => LocaleProvider()),
       ],
-      child: MaterialApp(
-        title: 'AI Photo Geolocation',
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-          useMaterial3: true,
-        ),
-        home: const HomeScreen(),
+      child: Consumer<LocaleProvider>(
+        builder: (context, localeProvider, _) {
+          return MaterialApp(
+            title: 'AI Photo Geolocation',
+            debugShowCheckedModeBanner: false,
+            locale: localeProvider.locale,
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: const [
+              AppLocalizationsDelegate(),
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+              useMaterial3: true,
+            ),
+            home: const HomeScreen(),
+          );
+        },
       ),
     );
   }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -21,7 +21,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 void main() {
   testWidgets('Home screen has expected widgets', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const WhereApp());
     await tester.pump();
     expect(find.text('Pick Image'), findsOneWidget);
     expect(find.text('Locate'), findsOneWidget);


### PR DESCRIPTION
## Summary
- configure localization and locale provider in `WhereApp`
- update widget tests to use `WhereApp`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*