### PR TITLE
Switch to mapbox_maps_flutter

### DIFF
--- a/app/lib/screens/result.dart
+++ b/app/lib/screens/result.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:mapbox_gl/mapbox_gl.dart';
+import '../widgets/map_widget.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../models/result_model.dart';
@@ -32,19 +32,9 @@ class ResultScreen extends StatelessWidget {
       body: Column(
         children: [
           Expanded(
-            child: MapboxMap(
-              accessToken: 'YOUR_MAPBOX_ACCESS_TOKEN',
-              initialCameraPosition: CameraPosition(
-                target: LatLng(result.latitude, result.longitude),
-                zoom: 12,
-              ),
-              onMapCreated: (controller) {
-                controller.addSymbol(
-                  SymbolOptions(
-                    geometry: LatLng(result.latitude, result.longitude),
-                  ),
-                );
-              },
+            child: MapWidget(
+              latitude: result.latitude,
+              longitude: result.longitude,
             ),
           ),
           Padding(

--- a/app/lib/widgets/map_widget.dart
+++ b/app/lib/widgets/map_widget.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart' as mapbox;
+
+class MapWidget extends StatefulWidget {
+  final double latitude;
+  final double longitude;
+
+  const MapWidget({
+    Key? key,
+    required this.latitude,
+    required this.longitude,
+  }) : super(key: key);
+
+  @override
+  State<MapWidget> createState() => _MapWidgetState();
+}
+
+class _MapWidgetState extends State<MapWidget> {
+  mapbox.MapboxMap? mapboxMap;
+
+  _onMapCreated(mapbox.MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    
+    // Add a marker at the location
+    mapboxMap.annotations.createPointAnnotationManager().then((pointAnnotationManager) async {
+      final options = <mapbox.PointAnnotationOptions>[
+        mapbox.PointAnnotationOptions(
+          geometry: mapbox.Point(
+            coordinates: mapbox.Position(
+              widget.longitude,
+              widget.latitude,
+            ),
+          ),
+        ),
+      ];
+      await pointAnnotationManager.createMulti(options);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // IMPORTANT: Replace with your PUBLIC Mapbox token (starts with pk.)
+    const String ACCESS_TOKEN = 'YOUR_PUBLIC_MAPBOX_TOKEN_HERE';
+    
+    // Set the access token
+    mapbox.MapboxOptions.setAccessToken(ACCESS_TOKEN);
+    
+    return mapbox.MapWidget(
+      key: const ValueKey("mapWidget"),
+      resourceOptions: mapbox.ResourceOptions(accessToken: ACCESS_TOKEN),
+      cameraOptions: mapbox.CameraOptions(
+        center: mapbox.Point(
+          coordinates: mapbox.Position(
+            widget.longitude,
+            widget.latitude,
+          ),
+        ),
+        zoom: 14.0,
+      ),
+      styleUri: mapbox.MapboxStyles.SATELLITE_STREETS,
+      onMapCreated: _onMapCreated,
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -36,10 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   image_picker: ^1.0.4
-  mapbox_gl:
-      git:
-        url: https://github.com/tobrun/flutter-mapbox-gl.git
-        ref: master
+  mapbox_maps_flutter: ^0.4.0
   share_plus: ^7.2.1
   provider: ^6.1.1
   shared_preferences: ^2.2.2

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -15,7 +15,7 @@ import 'package:app/l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:app/models/result_model.dart';
-import 'package:mapbox_gl/mapbox_gl.dart';
+import 'package:app/widgets/map_widget.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -58,7 +58,7 @@ void main() {
 
     expect(find.byKey(const Key('confidence_text')), findsOneWidget);
     expect(find.byKey(const Key('share_button')), findsOneWidget);
-    expect(find.byType(MapboxMap), findsOneWidget);
+    expect(find.byType(MapWidget), findsOneWidget);
   });
 
 }


### PR DESCRIPTION
## Summary
- replace old mapbox_gl dependency with mapbox_maps_flutter
- add new `MapWidget` for displaying maps
- use `MapWidget` in result screen
- update widget tests for new map implementation

## Testing
- `flutter test` *(fails: `flutter: command not found`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*