### PR TITLE
Switch to mapbox_maps_flutter

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data
+            android:name="com.mapbox.token"
+            android:value="pk.YOUR_PUBLIC_TOKEN_HERE" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -80,8 +80,10 @@
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>This app needs to find local network devices for debugging purposes.</string>
 	<key>NSBonjourServices</key>
-	<array>
-		<string>_dartobservatory._tcp</string>
-	</array>
+        <array>
+                <string>_dartobservatory._tcp</string>
+        </array>
+        <key>MBXAccessToken</key>
+        <string>pk.YOUR_PUBLIC_TOKEN_HERE</string>
 </dict>
 </plist>

--- a/app/lib/screens/result.dart
+++ b/app/lib/screens/result.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:mapbox_gl/mapbox_gl.dart';
+import '../widgets/map_widget.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../models/result_model.dart';
@@ -32,25 +32,15 @@ class ResultScreen extends StatelessWidget {
       body: Column(
         children: [
           Expanded(
-            child: MapboxMap(
-              accessToken: 'YOUR_MAPBOX_ACCESS_TOKEN',
-              initialCameraPosition: CameraPosition(
-                target: LatLng(result.latitude, result.longitude),
-                zoom: 12,
-              ),
-              onMapCreated: (controller) {
-                controller.addSymbol(
-                  SymbolOptions(
-                    geometry: LatLng(result.latitude, result.longitude),
-                  ),
-                );
-              },
+            child: MapWidget(
+              latitude: result.latitude,
+              longitude: result.longitude,
             ),
           ),
           Padding(
             padding: const EdgeInsets.all(16),
             child: Text(
-              'Confidence: \${(result.confidence * 100).toStringAsFixed(1)}%',
+              'Confidence: ${(result.confidence * 100).toStringAsFixed(1)}%',
               key: const Key('confidence_text'),
             ),
           ),

--- a/app/lib/widgets/map_widget.dart
+++ b/app/lib/widgets/map_widget.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart' as mapbox;
+
+class MapWidget extends StatefulWidget {
+  final double latitude;
+  final double longitude;
+
+  const MapWidget({
+    Key? key,
+    required this.latitude,
+    required this.longitude,
+  }) : super(key: key);
+
+  @override
+  State<MapWidget> createState() => _MapWidgetState();
+}
+
+class _MapWidgetState extends State<MapWidget> {
+  mapbox.MapboxMap? mapboxMap;
+
+  _onMapCreated(mapbox.MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    
+    // Add a marker at the location
+    mapboxMap.annotations.createPointAnnotationManager().then((pointAnnotationManager) async {
+      final options = <mapbox.PointAnnotationOptions>[
+        mapbox.PointAnnotationOptions(
+          geometry: mapbox.Point(
+            coordinates: mapbox.Position(
+              widget.longitude,
+              widget.latitude,
+            ),
+          ),
+        ),
+      ];
+      await pointAnnotationManager.createMulti(options);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // IMPORTANT: Replace with your PUBLIC Mapbox token (starts with pk.)
+    const String ACCESS_TOKEN = 'YOUR_PUBLIC_MAPBOX_TOKEN_HERE';
+    
+    // Set the access token
+    mapbox.MapboxOptions.setAccessToken(ACCESS_TOKEN);
+    
+    return mapbox.MapWidget(
+      key: const ValueKey("mapWidget"),
+      resourceOptions: mapbox.ResourceOptions(accessToken: ACCESS_TOKEN),
+      cameraOptions: mapbox.CameraOptions(
+        center: mapbox.Point(
+          coordinates: mapbox.Position(
+            widget.longitude,
+            widget.latitude,
+          ),
+        ),
+        zoom: 14.0,
+      ),
+      styleUri: mapbox.MapboxStyles.SATELLITE_STREETS,
+      onMapCreated: _onMapCreated,
+    );
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -329,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   js:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -381,41 +381,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
-  mapbox_gl:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: master
-      resolved-ref: "4a09cc4401bb77e900f005cc1e2f712193b997af"
-      url: "https://github.com/tobrun/flutter-mapbox-gl.git"
-    source: git
-    version: "0.16.0"
-  mapbox_gl_dart:
-    dependency: transitive
-    description:
-      name: mapbox_gl_dart
-      sha256: de6d03718e5eb05c9eb1ddaae7f0383b28acb5afa16405e1deed7ff04dd34f3d
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
-  mapbox_gl_platform_interface:
-    dependency: transitive
-    description:
-      path: mapbox_gl_platform_interface
-      ref: HEAD
-      resolved-ref: "4a09cc4401bb77e900f005cc1e2f712193b997af"
-      url: "https://github.com/tobrun/flutter-mapbox-gl.git"
-    source: git
-    version: "0.16.0"
-  mapbox_gl_web:
-    dependency: transitive
-    description:
-      path: mapbox_gl_web
-      ref: HEAD
-      resolved-ref: "4a09cc4401bb77e900f005cc1e2f712193b997af"
-      url: "https://github.com/tobrun/flutter-mapbox-gl.git"
-    source: git
-    version: "0.16.0"
   matcher:
     dependency: transitive
     description:
@@ -753,10 +718,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -36,10 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   image_picker: ^1.0.4
-  mapbox_gl:
-      git:
-        url: https://github.com/tobrun/flutter-mapbox-gl.git
-        ref: master
+  mapbox_maps_flutter: ^0.4.0
   share_plus: ^7.2.1
   provider: ^6.1.1
   shared_preferences: ^2.2.2

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -15,7 +15,7 @@ import 'package:app/l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:app/models/result_model.dart';
-import 'package:mapbox_gl/mapbox_gl.dart';
+import 'package:app/widgets/map_widget.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -58,7 +58,7 @@ void main() {
 
     expect(find.byKey(const Key('confidence_text')), findsOneWidget);
     expect(find.byKey(const Key('share_button')), findsOneWidget);
-    expect(find.byType(MapboxMap), findsOneWidget);
+    expect(find.byType(MapWidget), findsOneWidget);
   });
 
 }


### PR DESCRIPTION
## Summary
- replace old mapbox_gl setup with mapbox_maps_flutter
- fix confidence display in result screen
- add Mapbox tokens for iOS and Android
- clean up dependency lock file

## Testing
- `flutter test` *(fails: flutter: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*