### PR TITLE
Add TorchServe config

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -1,0 +1,8 @@
+inference_address=http://0.0.0.0:8080
+management_address=http://0.0.0.0:8081
+metrics_address=http://0.0.0.0:8082
+model_store=/model-store
+load_models=all
+default_workers_per_model=1
+log_location=/app/logs/ts.log
+metrics_location=/app/logs/ts_metrics.log


### PR DESCRIPTION
## Summary
- create TorchServe config at `config/config.properties` for Docker use
- keep `scripts/init-db.sql` intact

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*