### PR TITLE
Simplify GPU Dockerfile

### DIFF
--- a/api/docker/Dockerfile.gpu
+++ b/api/docker/Dockerfile.gpu
@@ -1,177 +1,33 @@
-# Base image for TorchServe with GPU support
+# WhereIsThisPlace GPU backend image
 FROM pytorch/torchserve:0.10.0-gpu
 
-# Build-time arguments and Environment variables
-ARG DEBIAN_FRONTEND=noninteractive
-ENV PYTHONUNBUFFERED=1
-# Note: The warning about undefined $PYTHONPATH here is usually benign.
-# It means the base image might not have PYTHONPATH set, so it effectively becomes /app.
-ENV PYTHONPATH="/app:${PYTHONPATH}"
-ENV PATH="/usr/local/cuda/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
-ENV TORCHSERVE_CONFIG_FILE="/app/config/config.properties"
-
-# Switch to root user for system package installation
+# Install Poetry and project dependencies
 USER root
-
-# 1. System dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    ca-certificates \
-    wget \
-    curl \
-    # For psycopg2 build from source if needed (though poetry should handle prebuilt)
-    libpq-dev \
-    # For potential other native extensions
-    gcc \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
-
-# 2. Application setup
 WORKDIR /app
 
-# Copy application source code
-# Assuming Dockerfile is in 'api/docker/', and context is project root '.'
-COPY ../../api/ ./api/
-COPY ../../ml/ ./ml/
-COPY ../../scripts/ ./scripts/
+# Copy application code
+COPY ../../api /app/api
+COPY ../../ml  /app/ml
 
-# 3. Install Python dependencies via Poetry
-# Copy Poetry configuration files to a location where poetry can find them relative to its execution directory
-COPY ../../api/pyproject.toml ./api/
-COPY ../../api/poetry.lock ./api/
+# Copy Poetry files
+COPY ../../api/pyproject.toml /app/api/
+COPY ../../api/poetry.lock /app/api/
 
-# Install Poetry itself
-RUN pip install poetry==1.8.3
+RUN pip install --no-cache-dir poetry==1.8.3 && \
+    poetry config virtualenvs.create false && \
+    poetry --directory /app/api install --no-interaction --no-ansi --only main --no-root
 
-# Configure Poetry to not create virtualenvs and install dependencies
-# Running poetry from /app, targeting the ./api directory for project files
-RUN poetry config virtualenvs.create false && \
-    poetry --directory ./api install --no-interaction --no-ansi --only main --no-root
-
-# Install additional dependencies that might not be in pyproject.toml or for specific versions
-# python-multipart is needed for FastAPI file uploads
-# faiss-gpu for GPU-accelerated similarity search
-RUN pip install --no-cache-dir \
-    python-multipart \
-    faiss-gpu \
-    asyncpg==0.29.0 \
-    psycopg[binary]==3.2.3 \
-    pgvector==0.2.0
-
-# 4. Prepare model store and TorchServe configuration
-RUN mkdir -p /model-store /app/config /app/logs
-RUN chown -R model-server:model-server /model-store /app/logs
-
-# Copy model files from the project's 'models' directory (relative to build context)
+# Bundle models inside the image
 COPY ../../models/where.mar /model-store/
 COPY ../../models/mapillary_WPCA128.pth.tar /model-store/
-# Add more COPY lines if you have other model-related files
 
-# Verify models are copied and set permissions
-RUN if ls /model-store/where.mar >/dev/null 2>&1; then \
-        echo "where.mar copied to /model-store/"; \
-    else \
-        echo "WARNING: where.mar not found in context's models/ directory"; \
-    fi && \
-    ls -la /model-store/ && \
-    chown -R model-server:model-server /model-store
+# Provide fallback TorchServe configuration
+RUN mkdir -p /app/config && \
+    echo "inference_address=http://0.0.0.0:8080" > /app/config/config.properties && \
+    echo "management_address=http://0.0.0.0:8081" >> /app/config/config.properties && \
+    echo "metrics_address=http://0.0.0.0:8082" >> /app/config/config.properties && \
+    echo "model_store=/model-store" >> /app/config/config.properties && \
+    echo "load_models=where.mar" >> /app/config/config.properties
 
-# Create TorchServe configuration file for auto-loading models
-# This tells TorchServe to load 'where.mar' on startup.
-RUN echo "inference_address=http://0.0.0.0:8080" > ${TORCHSERVE_CONFIG_FILE} && \
-    echo "management_address=http://0.0.0.0:8081" >> ${TORCHSERVE_CONFIG_FILE} && \
-    echo "metrics_address=http://0.0.0.0:8082" >> ${TORCHSERVE_CONFIG_FILE} && \
-    echo "model_store=/model-store" >> ${TORCHSERVE_CONFIG_FILE} && \
-    echo "load_models=where.mar" >> ${TORCHSERVE_CONFIG_FILE} && \
-    echo "default_workers_per_model=1" >> ${TORCHSERVE_CONFIG_FILE} && \
-    echo "NUM_WORKERS=1" >> ${TORCHSERVE_CONFIG_FILE} && \
-    chown model-server:model-server ${TORCHSERVE_CONFIG_FILE}
-
-# 5. Create startup script
-RUN echo '#!/bin/bash' > /app/start.sh && \
-    echo 'set -e' >> /app/start.sh && \
-    echo '' >> /app/start.sh && \
-    echo 'echo "Starting WhereIsThisPlace services..."' >> /app/start.sh && \
-    echo 'echo "Models available in /model-store:"' >> /app/start.sh && \
-    echo 'ls -la /model-store/' >> /app/start.sh && \
-    echo '' >> /app/start.sh && \
-    echo '# Start TorchServe with the config file that auto-loads models' >> /app/start.sh && \
-    echo 'echo "Starting TorchServe with configuration: ${TORCHSERVE_CONFIG_FILE}"' >> /app/start.sh && \
-    echo 'torchserve \\' >> /app/start.sh && \
-    echo '    --start \\' >> /app/start.sh && \
-    echo '    --model-store /model-store \\' >> /app/start.sh && \
-    echo '    --ts-config ${TORCHSERVE_CONFIG_FILE} \\' >> /app/start.sh && \
-    echo '    --log-config /app/config/log4j.properties & # Optional: if you have custom log4j settings' >> /app/start.sh && \
-    echo 'TORCHSERVE_PID=$!' >> /app/start.sh && \
-    echo '' >> /app/start.sh && \
-    echo '# Wait for TorchServe to be ready and the model to load' >> /app/start.sh && \
-    echo 'echo "Waiting for TorchServe to start and load models (up to 60s)..."' >> /app/start.sh && \
-    echo 'for i in {1..30}; do' >> /app/start.sh && \
-    echo '    if curl -s http://localhost:8081/ping > /dev/null 2>&1 && curl -s http://localhost:8081/models/where 2>/dev/null | grep -q "\\"status\\": \\"READY\\""; then' >> /app/start.sh && \
-    echo '        echo "TorchServe is running and model '"'"'where'"'"' is loaded and ready!"' >> /app/start.sh && \
-    echo '        break' >> /app/start.sh && \
-    echo '    fi' >> /app/start.sh && \
-    echo '    if [ $i -eq 30 ]; then' >> /app/start.sh && \
-    echo '        echo "WARNING: Timeout waiting for model to load or TorchServe to start properly."' >> /app/start.sh && \
-    echo '        echo "TorchServe ping status:"' >> /app/start.sh && \
-    echo '        curl -s http://localhost:8081/ping || echo "Ping failed"' >> /app/start.sh && \
-    echo '        echo "TorchServe model status:"' >> /app/start.sh && \
-    echo '        curl -s http://localhost:8081/models/where || echo "Model status check failed"' >> /app/start.sh && \
-    echo '    fi' >> /app/start.sh && \
-    echo '    sleep 2' >> /app/start.sh && \
-    echo 'done' >> /app/start.sh && \
-    echo '' >> /app/start.sh && \
-    echo '# Start FastAPI application' >> /app/start.sh && \
-    echo 'echo "Starting FastAPI application..."' >> /app/start.sh && \
-    echo 'cd /app' >> /app/start.sh && \
-    echo 'exec uvicorn api.main:app --host 0.0.0.0 --port 8000 --forwarded-allow-ips="*" --log-config /app/config/uvicorn_log_config.json' >> /app/start.sh && \
-    chmod +x /app/start.sh
-
-# Optional: Add custom log4j.properties for TorchServe if needed
-# COPY config/log4j.properties /app/config/log4j.properties
-# RUN chown model-server:model-server /app/config/log4j.properties
-
-# Optional: Add custom uvicorn_log_config.json for FastAPI if needed
-RUN echo '{' > /app/config/uvicorn_log_config.json && \
-    echo '    "version": 1,' >> /app/config/uvicorn_log_config.json && \
-    echo '    "disable_existing_loggers": false,' >> /app/config/uvicorn_log_config.json && \
-    echo '    "formatters": {' >> /app/config/uvicorn_log_config.json && \
-    echo '        "default": {' >> /app/config/uvicorn_log_config.json && \
-    echo '            "()": "uvicorn.logging.DefaultFormatter",' >> /app/config/uvicorn_log_config.json && \
-    echo '            "fmt": "%(levelprefix)s %(asctime)s %(message)s",' >> /app/config/uvicorn_log_config.json && \
-    echo '            "datefmt": "%Y-%m-%d %H:%M:%S"' >> /app/config/uvicorn_log_config.json && \
-    echo '        }' >> /app/config/uvicorn_log_config.json && \
-    echo '    },' >> /app/config/uvicorn_log_config.json && \
-    echo '    "handlers": {' >> /app/config/uvicorn_log_config.json && \
-    echo '        "default": {' >> /app/config/uvicorn_log_config.json && \
-    echo '            "formatter": "default",' >> /app/config/uvicorn_log_config.json && \
-    echo '            "class": "logging.StreamHandler",' >> /app/config/uvicorn_log_config.json && \
-    echo '            "stream": "ext://sys.stderr"' >> /app/config/uvicorn_log_config.json && \
-    echo '        }' >> /app/config/uvicorn_log_config.json && \
-    echo '    },' >> /app/config/uvicorn_log_config.json && \
-    echo '    "loggers": {' >> /app/config/uvicorn_log_config.json && \
-    echo '        "uvicorn": {"handlers": ["default"], "level": "INFO"},' >> /app/config/uvicorn_log_config.json && \
-    echo '        "uvicorn.error": {"level": "INFO"},' >> /app/config/uvicorn_log_config.json && \
-    echo '        "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": false}' >> /app/config/uvicorn_log_config.json && \
-    echo '    }' >> /app/config/uvicorn_log_config.json && \
-    echo '}' >> /app/config/uvicorn_log_config.json && \
-    chown model-server:model-server /app/config/uvicorn_log_config.json
-
-
-# 6. Expose necessary ports
-# 8080: TorchServe inference API
-# 8081: TorchServe management API
-# 8082: TorchServe metrics API
-# 8000: FastAPI application
-EXPOSE 8000 8080 8081 8082
-
-# Healthcheck for TorchServe (optional but recommended)
-# HEALTHCHECK --interval=30s --timeout=10s --start-period=5m --retries=3 \
-# CMD curl -f http://localhost:8081/ping || exit 1
-
-# 7. Set the default command to run the startup script
-# The TorchServe user is 'model-server'. FastAPI will run as this user too.
 USER model-server
-CMD ["/app/start.sh"]
+CMD ["torchserve", "--start", "--model-store", "/model-store", "--ncs", "--ts-config", "/app/config/config.properties"]


### PR DESCRIPTION
## Summary
- strip down `Dockerfile.gpu` to essential steps
- bake model artifacts into the image
- supply fallback TorchServe config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*