### PR TITLE
Fix ECR workflow

### DIFF
--- a/.github/workflows/push-ecr.yml
+++ b/.github/workflows/push-ecr.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   AWS_REGION: eu-central-1
-  IMAGE_NAME: ${{ secrets.ECR_REPO }} # Example: 123456789012.dkr.ecr.eu-central-1.amazonaws.com/where-backend
+  IMAGE_NAME: 726580147864.dkr.ecr.eu-central-1.amazonaws.com/where-backend
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- update the IMAGE_NAME variable in the ECR workflow
- ensure the workflow ends with a newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*