### PR TITLE
Update health check to query TorchServe

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.routes.predict import router as predict_router
 # Corrected import for middleware:
 from api.middleware import EphemeralUploadMiddleware, RateLimitMiddleware
+import http.client
+import json
+from urllib.parse import urlparse
 
 app = FastAPI()
 
@@ -32,8 +35,36 @@ def read_root():
     return {"message": "Hello World"}
 
 
+TORCHSERVE_MANAGEMENT_URL = "http://localhost:8081"
+
+
 @app.get("/health")
 def health_check():
-    """Simple health check endpoint used by deployment probes."""
-    return {"status": "ok"}
+    """Report FastAPI and TorchServe status."""
+    parsed = urlparse(TORCHSERVE_MANAGEMENT_URL)
+    models_data = {}
+    torchserve_status = "unhealthy"
+    try:
+        conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+        conn.request("GET", "/models")
+        resp = conn.getresponse()
+        body = resp.read().decode()
+        if resp.status == 200:
+            data = json.loads(body)
+            models_data = data
+            if any(m.get("modelName") == "where" for m in data.get("models", [])):
+                torchserve_status = "healthy"
+            else:
+                torchserve_status = 'unhealthy - model "where" not found'
+        else:
+            torchserve_status = f"unhealthy, status: {resp.status}, body: {body}"
+    except Exception as e:
+        torchserve_status = f"unhealthy: {e}"
+
+    return {
+        "fastapi_status": "healthy",
+        "torchserve_status": torchserve_status,
+        "torchserve_models": models_data,
+        "message": "API is operational",
+    }
 

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -30,7 +30,9 @@ def test_health_endpoint_returns_200():
     client = get_fresh_client()
     resp = client.get("/health")
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    data = resp.json()
+    assert data.get("fastapi_status") == "healthy"
+    assert "torchserve_status" in data
 
 
 def test_predict_returns_expected_data():


### PR DESCRIPTION
## Summary
- improve `/health` to query TorchServe management API on port 8081
- adjust endpoint tests for new response shape

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*