### PR TITLE
Add async DB pool

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -1,0 +1,23 @@
+import os
+
+import asyncpg
+from fastapi import FastAPI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+async def init_db(app: FastAPI):
+    """Initialize a connection pool and attach it to the FastAPI app."""
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is not set")
+    app.state.pool = await asyncpg.create_pool(dsn=database_url)
+    return app.state.pool
+
+
+async def close_db(app: FastAPI):
+    """Close the connection pool stored on the FastAPI app."""
+    pool = getattr(app.state, "pool", None)
+    if pool is not None:
+        await pool.close()

--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from api.routes.predict import router as predict_router
 from api.middleware import EphemeralUploadMiddleware, RateLimitMiddleware
+from api.db import init_db, close_db
 import requests
 import os
 
@@ -72,4 +73,14 @@ def health_check():
         "torchserve_models": models_data,
         "message": "API is operational",
     }
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await init_db(app)
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await close_db(app)
 

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(1, str(ROOT / "api"))
+
+from api.db import init_db, close_db
+
+
+class DummyPool:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def acquire(self):
+        return "conn"
+
+    async def close(self):
+        self.closed = True
+
+
+@patch("api.db.asyncpg.create_pool")
+@pytest.mark.asyncio
+async def test_pool_returns_connection(mock_create_pool):
+    mock_create_pool.return_value = DummyPool()
+    app = FastAPI()
+    await init_db(app)
+    conn = await app.state.pool.acquire()
+    assert conn == "conn"
+    await close_db(app)
+    assert app.state.pool.closed


### PR DESCRIPTION
## Notes
- `asyncpg` not installed in this environment, so tests fail during import.

## Summary
- implement `api.db` with async connection pool
- register pool startup/shutdown hooks in `api.main`
- add unit test for DB pool behaviour

------
https://chatgpt.com/codex/tasks/task_e_683b38c4b90c8332b98fa62ac83dc137