### PR TITLE
Implement vector match repository and update tests

### DIFF
--- a/api/repositories/match.py
+++ b/api/repositories/match.py
@@ -1,0 +1,36 @@
+import os
+from typing import Optional, Dict, Any
+
+import asyncpg
+import numpy as np
+
+
+async def nearest(vec: np.ndarray) -> Optional[asyncpg.Record]:
+    """Return the closest photo to the given vector.
+
+    Parameters
+    ----------
+    vec: np.ndarray
+        Embedding vector with dimension matching the ``vlad`` column.
+
+    Returns
+    -------
+    asyncpg.Record | None
+        Row containing ``lat``, ``lon`` and ``score`` fields or ``None`` if no
+        data is found.
+    """
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is not set")
+
+    conn = await asyncpg.connect(dsn=database_url)
+    try:
+        row = await conn.fetchrow(
+            "SELECT lat, lon, 1 - (vlad <#> $1) AS score "
+            "FROM photos ORDER BY vlad <#> $1 LIMIT 1",
+            vec.tolist(),
+        )
+        return row
+    finally:
+        await conn.close()
+

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -22,6 +22,8 @@ def test_app_is_fastapi_instance():
 class DummyUploadFile:
     def __init__(self, data: bytes):
         self.data = data
+        self.filename = "test.jpg"
+        self.content_type = "image/jpeg"
 
     async def read(self) -> bytes:
         return self.data

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import asyncio
+from unittest.mock import patch
+import os
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(1, str(ROOT / "api"))
+
+from api.repositories.match import nearest
+
+
+class DummyConn:
+    def __init__(self, result):
+        self.result = result
+        self.queries = []
+
+    async def fetchrow(self, query, vec):
+        self.queries.append((query, vec))
+        return self.result
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_nearest_returns_expected_row():
+    expected = {"lat": 1.0, "lon": 2.0, "score": 0.9}
+
+    dummy = DummyConn(expected)
+    with patch("api.repositories.match.asyncpg.connect", return_value=dummy):
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://"}):
+            result = await nearest(np.array([0.1, 0.2]))
+
+    assert result == expected
+    assert dummy.queries
+    query, _ = dummy.queries[0]
+    assert "ORDER BY vlad <#> $1" in query
+


### PR DESCRIPTION
## Summary
- update DummyUploadFile test helper with filename and content type
- implement vector similarity search and use index-friendly ORDER BY
- verify constructed SQL in the match repository test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi & numpy)*

------
https://chatgpt.com/codex/tasks/task_e_683b424ac370833296ed964e52d06684