### PR TITLE
Extend /predict route to return DB match

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, AsyncMock
 import asyncio
 
 API_ROOT = Path(__file__).resolve().parents[1]
@@ -32,22 +32,21 @@ class DummyUploadFile:
 
 def test_predict_endpoint_returns_location():
     from routes.predict import predict
-    from unittest.mock import patch, Mock
-    
-    # Mock the requests.post call
+
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"latitude": 0.0, "longitude": 0.0, "confidence": 0.1}
-    
-    with patch('routes.predict.requests.post', return_value=mock_response):
+    mock_response.json.return_value = {"embedding": [0.0] * 128}
+
+    with patch('routes.predict.requests.post', return_value=mock_response), \
+        patch('routes.predict.nearest', new_callable=AsyncMock) as mock_nearest:
+        mock_nearest.return_value = {"lat": 0.0, "lon": 0.0, "score": 0.1}
         file = DummyUploadFile(b"dummy")
         data = asyncio.run(predict(photo=file))
-        
-        # Check the wrapper structure
+
         assert data["status"] == "success"
         assert data["filename"] == "test.jpg"
         assert data["message"] == "Prediction completed successfully"
-        assert data["prediction"] == {"latitude": 0.0, "longitude": 0.0, "confidence": 0.1}
+        assert data["prediction"] == {"lat": 0.0, "lon": 0.0, "score": 0.1}
 
 
 def test_rate_limit_middleware_added():

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,6 +1,10 @@
+from starlette.requests import Client as StarletteClient
+
+
 class Request:
-    def __init__(self, body: bytes = b""):
+    def __init__(self, body: bytes = b"", client: StarletteClient | None = None):
         self._body = body
+        self.client = client or StarletteClient()
 
     async def body(self) -> bytes:
         return self._body
@@ -28,6 +32,10 @@ class FastAPI:
             self.router.routes.append(type('Route', (), {'path': path}))
             return func
         return decorator
+
+    def include_router(self, router):
+        for route in getattr(router, 'routes', []):
+            self.router.routes.append(route)
 
 class APIRouter:
     def __init__(self):

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -1,4 +1,5 @@
 from . import Request
+from starlette.responses import Response as StarletteResponse
 
 
 class Response:
@@ -13,26 +14,57 @@ class Response:
 class TestClient:
     def __init__(self, app):
         self.app = app
+        self._middleware = [mw.cls(app) for mw in app.user_middleware]
+
+    def _apply_middleware(self, handler):
+        import inspect
+
+        async def call(req):
+            async def run_next(r):
+                if inspect.signature(handler).parameters:
+                    res = handler(r)
+                else:
+                    res = handler()
+                if hasattr(res, '__await__'):
+                    import asyncio
+                    res = await res
+                return res
+
+            next_call = run_next
+            for mw_instance in reversed(self._middleware):
+                current = next_call
+                if hasattr(mw_instance, 'dispatch'):
+                    async def wrapper(r, mw_instance=mw_instance, next_call=current):
+                        return await mw_instance.dispatch(r, next_call)
+
+                    next_call = wrapper
+            
+            return await next_call(req)
+
+        return call
 
     def post(self, path, data=None):
         handler = self.app._routes.get(path)
         if not handler:
             return Response(None, 404)
         req = Request(data or b"")
-        result = handler(req)
-        if hasattr(result, '__await__'):
-            import asyncio
-            result = asyncio.get_event_loop().run_until_complete(result)
+        call = self._apply_middleware(handler)
+        import asyncio
+        result = asyncio.run(call(req))
+        if isinstance(result, StarletteResponse):
+            return Response(result.body, result.status_code)
         return Response(result)
 
     def get(self, path):
         handler = self.app._routes.get(path)
         if not handler:
             return Response(None, 404)
-        result = handler()
-        if hasattr(result, '__await__'):
-            import asyncio
-            result = asyncio.get_event_loop().run_until_complete(result)
+        req = Request()
+        call = self._apply_middleware(handler)
+        import asyncio
+        result = asyncio.run(call(req))
+        if isinstance(result, StarletteResponse):
+            return Response(result.body, result.status_code)
         return Response(result)
 
 

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -8,6 +8,17 @@ class Response:
         return self._json
 
 
+class _Exceptions:
+    class ConnectionError(Exception):
+        pass
+
+    class Timeout(Exception):
+        pass
+
+
+exceptions = _Exceptions()
+
+
 def post(url, data=None, timeout=None):
     return Response({"embedding": [0.0]*128})
 

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -36,16 +36,18 @@ def test_health_endpoint_returns_200():
         assert "torchserve_status" in data
 
 
-@patch("api.routes.predict.requests.post")
-def test_predict_returns_expected_data(mock_post):
+@patch("routes.predict.nearest", new_callable=AsyncMock)
+@patch("routes.predict.requests.post")
+def test_predict_returns_expected_data(mock_post, mock_nearest):
     mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = {"lat": 1, "lon": 2}
+    mock_post.return_value.json.return_value = {"embedding": [0.0] * 128}
+    mock_nearest.return_value = {"lat": 1.0, "lon": 2.0, "score": 0.5}
     file = DummyUploadFile(b"dummy")
     result = asyncio.run(predict(photo=file))
     assert result == {
         "status": "success",
         "filename": "test.jpg",
-        "prediction": {"lat": 1, "lon": 2},
+        "prediction": {"lat": 1.0, "lon": 2.0, "score": 0.5},
         "message": "Prediction completed successfully",
     }
 


### PR DESCRIPTION
## Summary
- update predict endpoint to fetch embedding from TorchServe and query DB via `nearest`
- add GeoResult dataclass to format prediction
- enhance FastAPI stubs with router inclusion and middleware-aware TestClient
- extend requests stub with exception classes
- update tests to mock `nearest` and expect `score`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6883336083328f9efe04c1797668