### PR TITLE
Add engine mode toggle to Flutter app

### DIFF
--- a/app/lib/models/engine.dart
+++ b/app/lib/models/engine.dart
@@ -1,0 +1,13 @@
+enum Engine { fastai, openai }
+
+extension EngineExt on Engine {
+  String get label {
+    switch (this) {
+      case Engine.openai:
+        return 'OpenAI';
+      case Engine.fastai:
+      default:
+        return 'Default';
+    }
+  }
+}

--- a/app/lib/providers/geo_provider.dart
+++ b/app/lib/providers/geo_provider.dart
@@ -2,18 +2,21 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 
 import '../models/result_model.dart';
+import '../models/engine.dart';
 import '../services/api.dart';
 
 /// Notifier that performs the geolocation call and stores the last result.
 class GeoProvider extends ChangeNotifier {
-  GeoProvider();
+  GeoProvider([this._locate = Api.locate]);
+
+  final Future<ResultModel> Function(File, Engine) _locate;
 
   ResultModel? _result;
   ResultModel? get result => _result;
 
   /// Upload [file] to the backend; notify listeners when done.
-  Future<ResultModel> locate(File file) async {
-    final res = await Api.locate(file);   // <-- static call
+  Future<ResultModel> locate(File file, Engine engine) async {
+    final res = await _locate(file, engine);
     _result = res;
     notifyListeners();
     return res;

--- a/app/lib/providers/settings_provider.dart
+++ b/app/lib/providers/settings_provider.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/engine.dart';
+
 class SettingsProvider extends ChangeNotifier {
-  static const _sendToLlmKey = 'send_to_llm';
-  bool _sendToLlm = false;
-  bool get sendToLlm => _sendToLlm;
+  static const _engineKey = 'engine';
+  Engine _engine = Engine.fastai;
+  Engine get engine => _engine;
 
   SettingsProvider() {
     _load();
@@ -12,14 +14,20 @@ class SettingsProvider extends ChangeNotifier {
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
-    _sendToLlm = prefs.getBool(_sendToLlmKey) ?? false;
+    final value = prefs.getString(_engineKey);
+    if (value != null) {
+      _engine = Engine.values.firstWhere(
+        (e) => e.name == value,
+        orElse: () => Engine.fastai,
+      );
+    }
     notifyListeners();
   }
 
-  Future<void> toggleSendToLlm(bool value) async {
-    _sendToLlm = value;
+  Future<void> setEngine(Engine engine) async {
+    _engine = engine;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_sendToLlmKey, value);
+    await prefs.setString(_engineKey, engine.name);
     notifyListeners();
   }
 }

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import '../providers/geo_provider.dart';
+import '../providers/settings_provider.dart';
 import 'result.dart';
 import 'settings.dart';
 import '../l10n/app_localizations.dart';
@@ -42,7 +43,8 @@ class _HomeScreenState extends State<HomeScreen> {
       _loading = true;
     });
     final geo = context.read<GeoProvider>();
-    final result = await geo.locate(File(_image!.path));
+    final settings = context.read<SettingsProvider>();
+    final result = await geo.locate(File(_image!.path), settings.engine);
     if (!mounted) return;
     setState(() {
       _loading = false;

--- a/app/lib/screens/settings.dart
+++ b/app/lib/screens/settings.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/settings_provider.dart';
 import '../providers/locale_provider.dart';
+import '../models/engine.dart';
 import '../l10n/app_localizations.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -16,11 +17,19 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(title: Text(AppLocalizations.of(context).settings)),
       body: ListView(
         children: [
-          SwitchListTile(
-            key: const Key('send_to_llm_toggle'),
-            title: const Text('Send to OpenAI LLM'),
-            value: settings.sendToLlm,
-            onChanged: settings.toggleSendToLlm,
+          ListTile(
+            title: DropdownButton<Engine>(
+              key: const Key('engine_dropdown'),
+              value: settings.engine,
+              items: const [
+                DropdownMenuItem(
+                    value: Engine.fastai, child: Text('Default')),
+                DropdownMenuItem(value: Engine.openai, child: Text('OpenAI')),
+              ],
+              onChanged: (engine) {
+                if (engine != null) settings.setEngine(engine);
+              },
+            ),
           ),
           ListTile(
             title: DropdownButton<Locale>(

--- a/app/lib/services/api.dart
+++ b/app/lib/services/api.dart
@@ -4,9 +4,10 @@ import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:http/http.dart' as http;
 
 import 'package:app/models/result_model.dart';   // ← use the existing model
+import 'package:app/models/engine.dart';
 
 /* ---------- endpoint selection ---------- */
-const _prodHost = '18.184.4.124';
+const _prodHost = '52.28.72.57';
 const _androidEmulatorHost = '10.0.2.2';
 
 final String _baseUrl = (() {
@@ -19,8 +20,9 @@ final String _baseUrl = (() {
 class Api {
   Api._();
 
-  static Future<ResultModel> locate(File image) async {
-    final uri = Uri.parse('$_baseUrl/predict');
+  static Future<ResultModel> locate(File image, Engine engine) async {
+    final query = engine == Engine.openai ? '?mode=openai' : '';
+    final uri = Uri.parse('$_baseUrl/predict$query');
     final req = http.MultipartRequest('POST', uri)
       ..files.add(await http.MultipartFile.fromPath('photo', image.path));
 

--- a/app/test/geo_provider_test.dart
+++ b/app/test/geo_provider_test.dart
@@ -1,15 +1,14 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:app/providers/geo_provider.dart';
-import 'package:app/services/api.dart';
-import 'package:app/models/result_model.dart';
+import 'package:app/models/engine.dart';
 
 void main() {
   test('locate stores result and notifies listeners', () async {
-    final provider = GeoProvider(_FakeApi());
+    final provider = GeoProvider();
     var notified = false;
     provider.addListener(() => notified = true);
-    final result = await provider.locate(File('dummy'));
+    final result = await provider.locate(File('dummy'), Engine.fastai);
     expect(notified, isTrue);
     expect(result.latitude, 1);
     expect(provider.result, isNotNull);
@@ -17,9 +16,3 @@ void main() {
   });
 }
 
-class _FakeApi extends Api {
-  @override
-  Future<ResultModel> locate(File file) async {
-    return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
-  }
-}

--- a/app/test/settings_provider_test.dart
+++ b/app/test/settings_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:app/providers/settings_provider.dart';
+import 'package:app/models/engine.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -9,19 +10,19 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('defaults to false when no value stored', () async {
+  test('defaults to fastai when no value stored', () async {
     final provider = SettingsProvider();
     await Future.delayed(Duration.zero);
-    expect(provider.sendToLlm, isFalse);
+    expect(provider.engine, Engine.fastai);
   });
 
-  test('toggle persists value', () async {
+  test('setEngine persists value', () async {
     var provider = SettingsProvider();
     await Future.delayed(Duration.zero);
-    await provider.toggleSendToLlm(true);
+    await provider.setEngine(Engine.openai);
 
     provider = SettingsProvider();
     await Future.delayed(Duration.zero);
-    expect(provider.sendToLlm, isTrue);
+    expect(provider.engine, Engine.openai);
   });
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -7,12 +7,11 @@ import 'dart:typed_data';
 import 'package:app/main.dart';
 import 'package:app/screens/home_screen.dart';
 import 'package:app/screens/settings.dart';
-import 'package:app/services/api.dart';
 import 'package:app/providers/geo_provider.dart';
 import 'package:app/providers/locale_provider.dart';
 import 'package:app/providers/settings_provider.dart';
 import 'package:app/l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:app/models/engine.dart';
 import 'package:provider/provider.dart';
 import 'package:app/models/result_model.dart';
 import 'package:app/widgets/map_widget.dart';
@@ -31,10 +30,15 @@ void main() {
 
   testWidgets('Navigate from home to result page', (WidgetTester tester) async {
     final key = GlobalKey();
-    final api = _FakeApi();
+    final fakeLocate =
+        (File file, Engine engine) async => ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
     await tester.pumpWidget(
-      ChangeNotifierProvider(
-        create: (_) => GeoProvider(api),
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => GeoProvider(fakeLocate)),
+          ChangeNotifierProvider(create: (_) => SettingsProvider()),
+          ChangeNotifierProvider(create: (_) => LocaleProvider()),
+        ],
         child: MaterialApp(
           localizationsDelegates: const [
             AppLocalizationsDelegate(),
@@ -63,9 +67,3 @@ void main() {
 
 }
 
-class _FakeApi extends Api {
-  @override
-  Future<ResultModel> locate(File file) async {
-    return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
-  }
-}


### PR DESCRIPTION
## Summary
- add `Engine` enum for selecting inference mode
- switch API base host to `52.28.72.57`
- allow engine selection in settings screen
- propagate engine to API calls
- update providers and tests accordingly

## Testing
- `pre-commit` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b721c06b48332a5988c7209d92dc7