### PR TITLE
Fix DB connection init error

### DIFF
--- a/api/repositories/match.py
+++ b/api/repositories/match.py
@@ -25,7 +25,8 @@ async def nearest(vec: np.ndarray) -> Optional[asyncpg.Record]:
     if not database_url:
         raise RuntimeError("DATABASE_URL is not set")
 
-    conn = await asyncpg.connect(dsn=database_url, init=init_connection)
+    conn = await asyncpg.connect(dsn=database_url)
+    await init_connection(conn)
     try:
         row = await conn.fetchrow(
             "SELECT lat, lon, 1 - (vlad <#> $1) AS score "

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,4 +1,9 @@
-from starlette.requests import Client as StarletteClient
+try:
+    from starlette.requests import Client as StarletteClient
+except Exception:  # pragma: no cover - fallback for tests without starlette stub
+    class StarletteClient:
+        def __init__(self, host: str = "test"):
+            self.host = host
 
 
 class Request:


### PR DESCRIPTION
## Summary
- initialize connections after `asyncpg.connect()`
- make FastAPI stub robust when `starlette` isn't our stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f498bdab4833282bdb54df424c12e