### PR TITLE
Add engine mode toggle

### DIFF
--- a/app/lib/models/engine.dart
+++ b/app/lib/models/engine.dart
@@ -1,0 +1,8 @@
+enum Engine {
+  defaultEngine,
+  openai,
+}
+
+extension EngineQuery on Engine {
+  String get queryValue => this == Engine.openai ? 'openai' : 'default';
+}

--- a/app/lib/providers/geo_provider.dart
+++ b/app/lib/providers/geo_provider.dart
@@ -3,17 +3,20 @@ import 'package:flutter/foundation.dart';
 
 import '../models/result_model.dart';
 import '../services/api.dart';
+import '../models/engine.dart';
 
 /// Notifier that performs the geolocation call and stores the last result.
 class GeoProvider extends ChangeNotifier {
-  GeoProvider();
+  final Future<ResultModel> Function(File, Engine) _locateFn;
+  GeoProvider([Future<ResultModel> Function(File, Engine)? locateFn])
+      : _locateFn = locateFn ?? Api.locate;
 
   ResultModel? _result;
   ResultModel? get result => _result;
 
   /// Upload [file] to the backend; notify listeners when done.
-  Future<ResultModel> locate(File file) async {
-    final res = await Api.locate(file);   // <-- static call
+  Future<ResultModel> locate(File file, Engine engine) async {
+    final res = await _locateFn(file, engine);
     _result = res;
     notifyListeners();
     return res;

--- a/app/lib/providers/settings_provider.dart
+++ b/app/lib/providers/settings_provider.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../models/engine.dart';
 
 class SettingsProvider extends ChangeNotifier {
-  static const _sendToLlmKey = 'send_to_llm';
-  bool _sendToLlm = false;
-  bool get sendToLlm => _sendToLlm;
+  static const _engineKey = 'engine';
+  Engine _engine = Engine.defaultEngine;
+  Engine get engine => _engine;
 
   SettingsProvider() {
     _load();
@@ -12,14 +13,15 @@ class SettingsProvider extends ChangeNotifier {
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
-    _sendToLlm = prefs.getBool(_sendToLlmKey) ?? false;
+    final stored = prefs.getString(_engineKey);
+    _engine = stored == 'openai' ? Engine.openai : Engine.defaultEngine;
     notifyListeners();
   }
 
-  Future<void> toggleSendToLlm(bool value) async {
-    _sendToLlm = value;
+  Future<void> setEngine(Engine value) async {
+    _engine = value;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_sendToLlmKey, value);
+    await prefs.setString(_engineKey, value.queryValue);
     notifyListeners();
   }
 }

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import '../providers/geo_provider.dart';
+import '../providers/settings_provider.dart';
 import 'result.dart';
 import 'settings.dart';
 import '../l10n/app_localizations.dart';
@@ -42,7 +43,8 @@ class _HomeScreenState extends State<HomeScreen> {
       _loading = true;
     });
     final geo = context.read<GeoProvider>();
-    final result = await geo.locate(File(_image!.path));
+    final engine = context.read<SettingsProvider>().engine;
+    final result = await geo.locate(File(_image!.path), engine);
     if (!mounted) return;
     setState(() {
       _loading = false;

--- a/app/lib/screens/settings.dart
+++ b/app/lib/screens/settings.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../providers/settings_provider.dart';
 import '../providers/locale_provider.dart';
 import '../l10n/app_localizations.dart';
+import '../models/engine.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -16,11 +17,24 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(title: Text(AppLocalizations.of(context).settings)),
       body: ListView(
         children: [
-          SwitchListTile(
-            key: const Key('send_to_llm_toggle'),
-            title: const Text('Send to OpenAI LLM'),
-            value: settings.sendToLlm,
-            onChanged: settings.toggleSendToLlm,
+          ListTile(
+            title: DropdownButton<Engine>(
+              key: const Key('engine_dropdown'),
+              value: settings.engine,
+              items: const [
+                DropdownMenuItem(
+                  value: Engine.defaultEngine,
+                  child: Text('Default'),
+                ),
+                DropdownMenuItem(
+                  value: Engine.openai,
+                  child: Text('OpenAI'),
+                ),
+              ],
+              onChanged: (engine) {
+                if (engine != null) settings.setEngine(engine);
+              },
+            ),
           ),
           ListTile(
             title: DropdownButton<Locale>(

--- a/app/lib/services/api.dart
+++ b/app/lib/services/api.dart
@@ -3,24 +3,29 @@ import 'dart:io' show File, Platform;
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:http/http.dart' as http;
 
-import 'package:app/models/result_model.dart';   // ← use the existing model
+import 'package:app/models/result_model.dart';
+import 'package:app/models/engine.dart';
 
 /* ---------- endpoint selection ---------- */
-const _prodHost = '18.184.4.124';
+const _backendHost = String.fromEnvironment('BACKEND_HOST', defaultValue: '52.28.72.57');
 const _androidEmulatorHost = '10.0.2.2';
 
 final String _baseUrl = (() {
-  if (!kDebugMode) return 'http://$_prodHost:8000';
-  return Platform.isAndroid ? 'http://$_androidEmulatorHost:8000'
-                            : 'http://$_prodHost:8000';
+  final host = kDebugMode && Platform.isAndroid
+      ? _androidEmulatorHost
+      : _backendHost;
+  return 'http://$host:8000';
 })();
 
 /* ---------- API service ---------- */
 class Api {
   Api._();
 
-  static Future<ResultModel> locate(File image) async {
-    final uri = Uri.parse('$_baseUrl/predict');
+  static Future<ResultModel> locate(File image, Engine engine) async {
+    var uri = Uri.parse('$_baseUrl/predict');
+    if (engine == Engine.openai) {
+      uri = uri.replace(queryParameters: {'mode': 'openai'});
+    }
     final req = http.MultipartRequest('POST', uri)
       ..files.add(await http.MultipartFile.fromPath('photo', image.path));
 

--- a/app/test/geo_provider_test.dart
+++ b/app/test/geo_provider_test.dart
@@ -1,15 +1,15 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:app/providers/geo_provider.dart';
-import 'package:app/services/api.dart';
+import 'package:app/models/engine.dart';
 import 'package:app/models/result_model.dart';
 
 void main() {
   test('locate stores result and notifies listeners', () async {
-    final provider = GeoProvider(_FakeApi());
+    final provider = GeoProvider(_fakeLocate);
     var notified = false;
     provider.addListener(() => notified = true);
-    final result = await provider.locate(File('dummy'));
+    final result = await provider.locate(File('dummy'), Engine.defaultEngine);
     expect(notified, isTrue);
     expect(result.latitude, 1);
     expect(provider.result, isNotNull);
@@ -17,9 +17,6 @@ void main() {
   });
 }
 
-class _FakeApi extends Api {
-  @override
-  Future<ResultModel> locate(File file) async {
-    return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
-  }
+Future<ResultModel> _fakeLocate(File file, Engine engine) async {
+  return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
 }

--- a/app/test/settings_provider_test.dart
+++ b/app/test/settings_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:app/providers/settings_provider.dart';
+import 'package:app/models/engine.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -9,19 +10,19 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('defaults to false when no value stored', () async {
+  test('defaults to default engine when no value stored', () async {
     final provider = SettingsProvider();
     await Future.delayed(Duration.zero);
-    expect(provider.sendToLlm, isFalse);
+    expect(provider.engine, Engine.defaultEngine);
   });
 
-  test('toggle persists value', () async {
+  test('setEngine persists value', () async {
     var provider = SettingsProvider();
     await Future.delayed(Duration.zero);
-    await provider.toggleSendToLlm(true);
+    await provider.setEngine(Engine.openai);
 
     provider = SettingsProvider();
     await Future.delayed(Duration.zero);
-    expect(provider.sendToLlm, isTrue);
+    expect(provider.engine, Engine.openai);
   });
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -7,7 +7,7 @@ import 'dart:typed_data';
 import 'package:app/main.dart';
 import 'package:app/screens/home_screen.dart';
 import 'package:app/screens/settings.dart';
-import 'package:app/services/api.dart';
+import 'package:app/models/engine.dart';
 import 'package:app/providers/geo_provider.dart';
 import 'package:app/providers/locale_provider.dart';
 import 'package:app/providers/settings_provider.dart';
@@ -31,10 +31,12 @@ void main() {
 
   testWidgets('Navigate from home to result page', (WidgetTester tester) async {
     final key = GlobalKey();
-    final api = _FakeApi();
     await tester.pumpWidget(
-      ChangeNotifierProvider(
-        create: (_) => GeoProvider(api),
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => GeoProvider(_fakeLocate)),
+          ChangeNotifierProvider(create: (_) => SettingsProvider()),
+        ],
         child: MaterialApp(
           localizationsDelegates: const [
             AppLocalizationsDelegate(),
@@ -63,9 +65,6 @@ void main() {
 
 }
 
-class _FakeApi extends Api {
-  @override
-  Future<ResultModel> locate(File file) async {
-    return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
-  }
+Future<ResultModel> _fakeLocate(File file, Engine engine) async {
+  return ResultModel(latitude: 1, longitude: 2, confidence: 0.5);
 }


### PR DESCRIPTION
## Summary
- configure backend host to default to `52.28.72.57`
- add `Engine` enum
- expose engine dropdown in settings
- propagate engine to API calls
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402a90cf5483328b9c8c4093fe6b68