### PR TITLE
Add bias guard test for Eiffel image

### DIFF
--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -46,7 +46,14 @@ def test_predict_endpoint_returns_location():
         assert data["status"] == "success"
         assert data["filename"] == "test.jpg"
         assert data["message"] == "Prediction completed successfully"
-        assert data["prediction"] == {"lat": 0.0, "lon": 0.0, "score": 0.1}
+
+        prediction = data["prediction"]
+        assert prediction["lat"] == 0.0
+        assert prediction["lon"] == 0.0
+        assert prediction["score"] == 0.1
+        assert prediction["confidence_level"] == "very_low"
+        assert "bias_warning" in prediction
+        assert prediction["source"] == "model"
 
 
 def test_rate_limit_middleware_added():

--- a/tests/test_bias_guard.py
+++ b/tests/test_bias_guard.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+import asyncio
+from unittest.mock import patch, AsyncMock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(1, str(ROOT / "api"))
+
+from routes.predict import predict
+
+class DummyUploadFile:
+    def __init__(self, data: bytes, filename: str = "test.jpg", content_type: str = "image/jpeg"):
+        self.data = data
+        self.filename = filename
+        self.content_type = content_type
+
+    async def read(self) -> bytes:
+        return self.data
+
+
+def load_test_image() -> bytes:
+    with open(ROOT / "eiffel.jpg", "rb") as f:
+        return f.read()
+
+
+@patch("routes.predict.OPENAI_API_KEY", None)
+@patch("routes.predict.nearest", new_callable=AsyncMock)
+@patch("routes.predict.requests.post")
+def test_eiffel_bias_detection(mock_post, mock_nearest):
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {"embedding": [0.0] * 128}
+    mock_nearest.return_value = {"lat": 40.75, "lon": -73.99, "score": 0.95}
+
+    image_data = load_test_image()
+    file = DummyUploadFile(image_data, filename="eiffel.jpg")
+
+    result = asyncio.run(predict(photo=file))
+    prediction = result["prediction"]
+
+    assert prediction["bias_warning"] is not None
+    assert prediction["score"] < 0.4

--- a/tests/test_eiffel_detailed.py
+++ b/tests/test_eiffel_detailed.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+import asyncio
+from unittest.mock import patch, AsyncMock
+
+ROOT = Path(__file__).resolve().parents[0]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(1, str(ROOT / "api"))
+
+from api.routes.predict import predict
+
+class DummyUploadFile:
+    def __init__(self, data: bytes, filename: str = "test.jpg", content_type: str = "image/jpeg"):
+        self.data = data
+        self.filename = filename
+        self.content_type = content_type
+
+    async def read(self) -> bytes:
+        return self.data
+
+def load_test_image() -> bytes:
+    with open(ROOT / "eiffel.jpg", "rb") as f:
+        return f.read()
+
+@patch("api.routes.predict.OPENAI_API_KEY", None)
+@patch("api.routes.predict.nearest", new_callable=AsyncMock)
+@patch("api.routes.predict.requests.post")
+def test_eiffel_bias_detection(mock_post, mock_nearest):
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {"embedding": [0.0] * 128}
+    mock_nearest.return_value = {"lat": 40.75, "lon": -73.99, "score": 0.95}
+
+    image_data = load_test_image()
+    file = DummyUploadFile(image_data, filename="eiffel.jpg")
+
+    result = asyncio.run(predict(photo=file))
+    prediction = result["prediction"]
+
+    print("=== Eiffel Tower Bias Detection Test Results ===")
+    print(f"filename: {result['filename']}")
+    print(f"bias_warning: {prediction.get('bias_warning')}")
+    print(f"score: {prediction.get('score')}")
+    print(f"original_score: {prediction.get('original_score')}")
+    print(f"confidence_level: {prediction.get('confidence_level')}")
+    print(f"warning: {prediction.get('warning')}")
+    print(f"source: {prediction.get('source')}")
+    
+    # Definition of Done checks
+    print("\n=== Definition of Done Verification ===")
+    
+    # Check 1: bias_warning field exists
+    has_bias_warning = prediction.get("bias_warning") is not None
+    print(f"✅ Has bias_warning field: {has_bias_warning}")
+    
+    # Check 2: confidence < 0.4
+    score = prediction.get("score", 1.0)
+    low_confidence = score < 0.4
+    print(f"✅ Confidence < 0.4: {low_confidence} (score: {score})")
+    
+    # Additional checks
+    print(f"Original score was: {prediction.get('original_score')}")
+    print(f"Confidence level: {prediction.get('confidence_level')}")
+    
+    assert has_bias_warning, "bias_warning field should be present"
+    assert low_confidence, f"Score should be < 0.4, got {score}"
+    
+    print("\n✅ All Definition of Done requirements met!")
+
+if __name__ == "__main__":
+    test_eiffel_bias_detection() 

--- a/tests/test_eiffel_detailed.py
+++ b/tests/test_eiffel_detailed.py
@@ -3,11 +3,11 @@ from pathlib import Path
 import asyncio
 from unittest.mock import patch, AsyncMock
 
-ROOT = Path(__file__).resolve().parents[0]
+ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 sys.path.insert(1, str(ROOT / "api"))
 
-from api.routes.predict import predict
+from routes.predict import predict
 
 class DummyUploadFile:
     def __init__(self, data: bytes, filename: str = "test.jpg", content_type: str = "image/jpeg"):
@@ -22,10 +22,15 @@ def load_test_image() -> bytes:
     with open(ROOT / "eiffel.jpg", "rb") as f:
         return f.read()
 
-@patch("api.routes.predict.OPENAI_API_KEY", None)
-@patch("api.routes.predict.nearest", new_callable=AsyncMock)
-@patch("api.routes.predict.requests.post")
-def test_eiffel_bias_detection(mock_post, mock_nearest):
+@patch("routes.predict.OPENAI_API_KEY", None)
+@patch("routes.predict.nearest", new_callable=AsyncMock)
+@patch("routes.predict.requests.post")
+def test_eiffel_bias_detection_detailed(mock_post, mock_nearest):
+    """
+    Detailed test for Eiffel Tower bias detection that verifies Definition of Done.
+    
+    Definition of Done: Unit test: Eiffel.jpg now returns bias_warning field and confidence < 0.4.
+    """
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {"embedding": [0.0] * 128}
     mock_nearest.return_value = {"lat": 40.75, "lon": -73.99, "score": 0.95}
@@ -67,4 +72,4 @@ def test_eiffel_bias_detection(mock_post, mock_nearest):
     print("\n✅ All Definition of Done requirements met!")
 
 if __name__ == "__main__":
-    test_eiffel_bias_detection() 
+    test_eiffel_bias_detection_detailed() 


### PR DESCRIPTION
## Summary
- adjust existing API test to new prediction format
- add bias guard unit test for Eiffel tower image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842967bfcb08332be74a6789caefd09