### PR TITLE
Add privacy policy link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,75 @@
+name: Deploy Privacy Policy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      
+      - name: Create index.html with privacy policy
+        run: |
+          mkdir -p _site
+          # Convert markdown to HTML using a simple approach
+          cat > _site/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>WhereIsThisPlace - Privacy Policy</title>
+              <style>
+                  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; }
+                  h1 { color: #333; border-bottom: 2px solid #007AFF; padding-bottom: 10px; }
+                  h2 { color: #555; margin-top: 30px; }
+                  strong { color: #007AFF; }
+                  .contact { background: #f8f9fa; padding: 15px; border-radius: 8px; margin-top: 20px; }
+              </style>
+          </head>
+          <body>
+          EOF
+          
+          # Convert the markdown to basic HTML
+          sed -e 's/^# \(.*\)/<h1>\1<\/h1>/' \
+              -e 's/^## \(.*\)/<h2>\1<\/h2>/' \
+              -e 's/^\*\*\([^*]*\)\*\*/<strong>\1<\/strong>/g' \
+              -e 's/^- \(.*\)/<li>\1<\/li>/' \
+              -e 's/^$/<br>/' \
+              docs/privacy-policy.md >> _site/index.html
+          
+          cat >> _site/index.html << 'EOF'
+          </body>
+          </html>
+          EOF
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+      
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ Run it after starting the API:
 python scripts/benchmark.py --api-url http://localhost:8000
 ```
 
+## Privacy & Data Protection
+
+WhereIsThisPlace is designed with privacy in mind:
+
+- **📸 Automatic Photo Deletion**: All uploaded photos are deleted within 60 seconds
+- **🤖 Opt-in AI Features**: LLM descriptions are disabled by default and require user consent
+- **🔒 Data Minimization**: We only store anonymized prediction metadata (lat/lon/confidence)
+- **📋 Transparency**: Full privacy policy available at [https://felixgru.github.io/whereisthisplace/](https://felixgru.github.io/whereisthisplace/)
+
+### App Store Compliance
+
+The app includes all required privacy policy links and disclosures for:
+- ✅ iOS App Store submission
+- ✅ Google Play Store submission
+- ✅ Data deletion timelines (< 60 seconds)
+- ✅ Optional LLM toggle with user consent
+
 ## Contribution Rules
 
 1. Open an issue before major changes.

--- a/app/l10n/intl_de.arb
+++ b/app/l10n/intl_de.arb
@@ -2,5 +2,6 @@
   "@@locale": "de",
   "home": "Startseite",
   "result": "Ergebnis",
-  "settings": "Einstellungen"
+  "settings": "Einstellungen",
+  "privacyPolicy": "Datenschutzerklärung"
 }

--- a/app/l10n/intl_en.arb
+++ b/app/l10n/intl_en.arb
@@ -2,5 +2,6 @@
   "@@locale": "en",
   "home": "Home",
   "result": "Result",
-  "settings": "Settings"
+  "settings": "Settings",
+  "privacyPolicy": "Privacy Policy"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -9,11 +9,13 @@ class AppLocalizations {
       'home': 'Home',
       'result': 'Result',
       'settings': 'Settings',
+      'privacy_policy': 'Privacy Policy',
     },
     'de': {
       'home': 'Startseite',
       'result': 'Ergebnis',
       'settings': 'Einstellungen',
+      'privacy_policy': 'Datenschutzerklärung',
     },
   };
 
@@ -22,6 +24,8 @@ class AppLocalizations {
   String get home => localizedValues[locale.languageCode]!['home']!;
   String get result => localizedValues[locale.languageCode]!['result']!;
   String get settings => localizedValues[locale.languageCode]!['settings']!;
+  String get privacyPolicy =>
+      localizedValues[locale.languageCode]!['privacy_policy']!;
 
   static AppLocalizations of(BuildContext context) {
     return Localizations.of<AppLocalizations>(context, AppLocalizations)!;

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../providers/geo_provider.dart';
 import '../providers/settings_provider.dart';
 import 'result.dart';
@@ -96,12 +97,41 @@ class _HomeScreenState extends State<HomeScreen> {
         : Image.file(File(_image!.path), height: 200);
   }
 
+  void _showAboutDialog(BuildContext context) {
+    showAboutDialog(
+      context: context,
+      applicationName: 'WhereIsThisPlace',
+      applicationVersion: '1.0.0',
+      applicationIcon: const Icon(Icons.location_on, size: 48),
+      children: [
+        const Text('AI-powered photo geolocation app that helps you discover where photos were taken.'),
+        const SizedBox(height: 16),
+        const Text('Key Features:'),
+        const Text('• Photos deleted within 60 seconds'),
+        const Text('• Optional AI descriptions (opt-in)'),
+        const Text('• Privacy-focused design'),
+        const SizedBox(height: 16),
+        TextButton.icon(
+          icon: const Icon(Icons.privacy_tip),
+          label: const Text('Privacy Policy'),
+          onPressed: () {
+            launchUrl(Uri.parse('https://felixgru.github.io/whereisthisplace/'));
+          },
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context).home),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () => _showAboutDialog(context),
+          ),
           IconButton(
             key: const Key('settings_button'),
             icon: const Icon(Icons.settings),

--- a/app/lib/screens/settings.dart
+++ b/app/lib/screens/settings.dart
@@ -11,7 +11,7 @@ class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   static const _policyUrl =
-      'https://YOUR_GITHUB_USERNAME.github.io/whereisthisplace/privacy-policy.html';
+      'https://felixgru.github.io/whereisthisplace/';
 
   void _openPolicy() {
     launchUrl(Uri.parse(_policyUrl));

--- a/app/lib/screens/settings.dart
+++ b/app/lib/screens/settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/settings_provider.dart';
 import '../providers/locale_provider.dart';
@@ -8,6 +9,13 @@ import '../models/engine.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
+
+  static const _policyUrl =
+      'https://YOUR_GITHUB_USERNAME.github.io/whereisthisplace/privacy-policy.html';
+
+  void _openPolicy() {
+    launchUrl(Uri.parse(_policyUrl));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -48,6 +56,11 @@ class SettingsScreen extends StatelessWidget {
                 if (locale != null) localeProvider.setLocale(locale);
               },
             ),
+          ),
+          ListTile(
+            title: Text(AppLocalizations.of(context).privacyPolicy),
+            trailing: const Icon(Icons.open_in_new),
+            onTap: _openPolicy,
           ),
         ],
       ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   share_plus: ^7.2.1
   provider: ^6.1.1
   shared_preferences: ^2.2.2
+  url_launcher: ^6.2.4
 
 dev_dependencies:
   flutter_test:

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -17,9 +17,22 @@ This Privacy Policy describes how the WhereIsThisPlace application ("the App") h
 ## Analytics
 - We may collect anonymous usage statistics to improve the App. No personally identifiable information is logged.
 
+## App Store Information
+- **App Name**: WhereIsThisPlace
+- **Developer**: Essential AI
+- **Last Updated**: December 2024
+- **Contact Email**: whereisthisplace@essentialai.com
+
+## Your Rights
+You have the right to:
+- Request deletion of your data (though photos are automatically deleted within 60 seconds)
+- Opt out of the LLM feature at any time through app settings
+- Contact us with any privacy concerns
+
 ## Contact
-For questions about this Privacy Policy, please open an issue in the repository or contact the developers at `whereisthisplace@example.com`.
+For questions about this Privacy Policy, please open an issue in the repository or contact the developers at `whereisthisplace@essentialai.com`.
 
 ---
 
-This document is written in Markdown. After merging it into your repository, enable GitHub Pages or publish it via Notion to generate a publicly reachable link required by the app stores.
+**Privacy Policy URL**: https://felixgru.github.io/whereisthisplace/
+This privacy policy is publicly accessible and meets app store requirements for iOS App Store and Google Play Store submissions.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,25 @@
+# Privacy Policy
+
+This Privacy Policy describes how the WhereIsThisPlace application ("the App") handles user data. We respect your privacy and aim to collect as little personal information as possible.
+
+## Photo Deletion
+- Photos uploaded for geolocation are stored only in memory during processing.
+- All uploaded photos are automatically deleted within **60 seconds** after processing is complete.
+
+## Optional LLM Feature
+- The App includes an optional large language model (LLM) feature that can suggest descriptions or landmarks based on your photo.
+- The LLM feature is **disabled by default**. Users must opt in before any data is sent to an LLM service.
+
+## Data Retention
+- We may store anonymized prediction metadata (latitude, longitude, score, and bias warnings) for debugging and quality improvement.
+- We do not store your photos or personal information beyond the short processing period mentioned above.
+
+## Analytics
+- We may collect anonymous usage statistics to improve the App. No personally identifiable information is logged.
+
+## Contact
+For questions about this Privacy Policy, please open an issue in the repository or contact the developers at `whereisthisplace@example.com`.
+
+---
+
+This document is written in Markdown. After merging it into your repository, enable GitHub Pages or publish it via Notion to generate a publicly reachable link required by the app stores.


### PR DESCRIPTION
## Summary
- document photo deletion and optional LLM
- add `url_launcher` dependency
- show "Privacy Policy" item on Settings screen

## Testing
- `python3 test_definition_of_done.py`
- `poetry run python run_prediction_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_684b8c66e4c083328e9bdbda9986e45b