### PR TITLE
Add Mapbox and Mapillary attribution footer

### DIFF
--- a/app/lib/screens/settings.dart
+++ b/app/lib/screens/settings.dart
@@ -62,6 +62,15 @@ class SettingsScreen extends StatelessWidget {
             trailing: const Icon(Icons.open_in_new),
             onTap: _openPolicy,
           ),
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(
+              child: Text(
+                '© Mapbox, © Mapillary CC-BY-SA 4.0',
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add footer attribution in the Settings page

## Testing
- `python3 test_definition_of_done.py`
- `poetry run python run_prediction_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_684c334eeaec833284eced4eef30dbba